### PR TITLE
Fixed broken link to EventHub Connection String

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ Parameters:
 
 | Parameter | Description |
 | --- | --- |
-| EventHubCS | Copy the Event Hubs namespace connection string as described [here](https://learn.microsoft.com/en-us/azure/event-hubs/event-hubs-get-connection-string"). |
+| EventHubCS | Copy the Event Hubs namespace connection string as described [here](https://learn.microsoft.com/en-us/azure/event-hubs/event-hubs-get-connection-string). |
 | StorageAccountCS | In the Azure Portal, navigate to the Storage Account created by this solution. Select "Access keys" from the left-hand navigation menu. Then, copy the connection string for key1. |
 | AzureSubscriptionID | In Azure Portal, browse your Subscriptions and copy the ID of the subscription used in this solution. |
     


### PR DESCRIPTION
For Event Hub Connection String setup during Run Simulation step, I removed an unnecessary double quote at the end of the link that was breaking it.