### PR TITLE
Added MaterialActualProperty relationship to MaterialActual

### DIFF
--- a/Ontologies/ISA95-WoT/CommonObjectModels/Part2/OperationsPerformance/MaterialActual.tm.json
+++ b/Ontologies/ISA95-WoT/CommonObjectModels/Part2/OperationsPerformance/MaterialActual.tm.json
@@ -16,6 +16,13 @@
       "dtdl:description": "The related object(s) makes up part of this material actual as the whole"
     },
     {
+      "href": "dtmi:digitaltwins:isa95:MaterialActualProperty;1",
+      "rel": "dtdl:hasValuesOf",
+      "@type": "dtdl:Relationship",
+      "dtdl:displayName": "has values of",
+      "dtdl:description": "The material actual property(s) of this material actual"
+    },
+    {
       "href": "dtmi:digitaltwins:isa95:MaterialSpecificationProperty;1",
       "rel": "dtdl:hasValuesOf",
       "@type": "dtdl:Relationship",

--- a/Ontologies/ISA95/CommonObjectModels/Part2/OperationsPerformance/MaterialActual.json
+++ b/Ontologies/ISA95/CommonObjectModels/Part2/OperationsPerformance/MaterialActual.json
@@ -22,6 +22,13 @@
             "name": "hasValuesOf",
             "displayName": "has values of",
             "description": "The material actual property(s) of this material actual",
+            "target": "dtmi:digitaltwins:isa95:MaterialActualProperty;1"
+        },
+        {
+            "@type": "Relationship",
+            "name": "hasValuesOf",
+            "displayName": "has values of",
+            "description": "The material actual property(s) of this material actual",
             "target": "dtmi:digitaltwins:isa95:MaterialSpecificationProperty;1"
         },
         {
@@ -90,7 +97,7 @@
             "comment": "Not part of the Standard Specs.",
             "target": "dtmi:digitaltwins:isa95:OperationalLocation;1",
             "maxMultiplicity": 1
-        },	
+        },
         {
             "@type": "Property",
             "name": "storageLocation",


### PR DESCRIPTION
While using this schema, I discovered there's a missing relationship between `MaterialActual` and `MaterialActualProperty`, that does exist in the ontologies and visuals I've seen. I believe it's a similar same relationship compared to the `MaterialSpecificationProperty` relationship, so reused the description from that one.