### PR TITLE
Removed the duplicate `MaterialSpecificationProperty` in `MaterialActual`

### DIFF
--- a/Ontologies/ISA95-WoT/CommonObjectModels/Part2/OperationsPerformance/MaterialActual.tm.json
+++ b/Ontologies/ISA95-WoT/CommonObjectModels/Part2/OperationsPerformance/MaterialActual.tm.json
@@ -23,13 +23,6 @@
       "dtdl:description": "The material actual property(s) of this material actual"
     },
     {
-      "href": "dtmi:digitaltwins:isa95:MaterialSpecificationProperty;1",
-      "rel": "dtdl:hasValuesOf",
-      "@type": "dtdl:Relationship",
-      "dtdl:displayName": "has values of",
-      "dtdl:description": "The material actual property(s) of this material actual"
-    },
-    {
       "href": "dtmi:digitaltwins:isa95:MaterialClass;1",
       "rel": "dtdl:correspondsToClass",
       "@type": "dtdl:Relationship",

--- a/Ontologies/ISA95/CommonObjectModels/Part2/OperationsPerformance/MaterialActual.json
+++ b/Ontologies/ISA95/CommonObjectModels/Part2/OperationsPerformance/MaterialActual.json
@@ -26,13 +26,6 @@
         },
         {
             "@type": "Relationship",
-            "name": "hasValuesOf",
-            "displayName": "has values of",
-            "description": "The material actual property(s) of this material actual",
-            "target": "dtmi:digitaltwins:isa95:MaterialSpecificationProperty;1"
-        },
-        {
-            "@type": "Relationship",
             "name": "correspondsToClass",
             "displayName": "Corresponds to",
             "description": "A cross-model association to element in the material model as explained in Clause 3.3.8. Identifies the associated material class or set of material classes of the specification for a specific process segment",


### PR DESCRIPTION
According to the [DTDLParser](https://github.com/digitaltwinconsortium/DTDLParser) the name of a relationship needs to be unique. Due to my earlier PR #37, `MaterialActual` now had a duplicate entry for `hasValuesOf`.

While going through the ontology, it appears the `MaterialSpecificationProperty` can be linked to the `Material model`, but `MaterialActual` isn't part of that model.

![Specification model of the ISA-95 manufacturing ontology](https://github.com/digitaltwinconsortium/ManufacturingOntologies/assets/462356/520c457a-8adc-4f0c-b7bc-e8c640a56df2)

Because of this, this update removes the `MaterialSpecificationProperty` to make the DTDL valid again and also reflect the correct representation (according to my own understanding).